### PR TITLE
Added a 'show-forever' mode and added a delay for manually close()

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ Then you can use it like this:
 
 That's it, you're ready to go!  
 
+Show a toast forever until you manually close it:
+```javascript
+ this.refs.toast.show('hello world!', DURATION.FOREVER);
+
+ // later on:
+ this.refs.toast.close('hello world!');
+```
+
+Optional you can pass a delay in seconds to the close()-method:
+```javascript
+ this.refs.toast.close('hello world!', 500);
+```
+
+Currently, the default delay for close() in FOREVER-mode is set to 250 ms (or this.props.defaultCloseDelay, which you can pass with)
+
+```jsx
+ <Toast ... defaultCloseDelay={100} />
+```
+
+
 
 ### Basic usage  
 

--- a/index.js
+++ b/index.js
@@ -14,21 +14,29 @@ import {
     Dimensions,
     Text,
 } from 'react-native'
-export const DURATION = { LENGTH_LONG: 2000, LENGTH_SHORT: 500 };
+
+export const DURATION = { 
+    LENGTH_LONG: 2000, 
+    LENGTH_SHORT: 500,
+    FOREVER: 0,
+};
+
 const {height, width} = Dimensions.get('window');
 
 export default class Toast extends Component {
 
     constructor(props) {
         super(props);
+
         this.state = {
             isShow: false,
             text: '',
             opacityValue: new Animated.Value(this.props.opacity),
         }
     }
+
     show(text, duration) {
-        this.duration = duration || DURATION.LENGTH_SHORT;
+        this.duration = typeof duration === 'number' ? duration : DURATION.LENGTH_SHORT;
 
         this.setState({
             isShow: true,
@@ -43,14 +51,16 @@ export default class Toast extends Component {
             }
         ).start(() => {
             this.isShow = true;
-            this.close();
+            if(duration !== DURATION.FOREVER) this.close();
         });
     }
 
-    close() {
-        let delay = this.duration;
-        
-        if (!this.isShow) return;
+    close( duration ) {
+        let delay = typeof duration === 'undefined' ? this.duration : duration;
+
+        if(delay === DURATION.FOREVER) delay = this.props.defaultCloseDelay || 250;
+
+        if (!this.isShow && !this.state.isShow) return;
         this.timer && clearTimeout(this.timer);
         this.timer = setTimeout(() => {
             Animated.timing(
@@ -85,7 +95,8 @@ export default class Toast extends Component {
                 pos = height - this.props.positionValue;
                 break;
         }
-        let view = this.state.isShow ?
+        
+        const view = this.state.isShow ?
             <View
                 style={[styles.container, { top: pos }]}
                 pointerEvents="none"


### PR DESCRIPTION
This PR adds the feature to show a Toast forever until a separate call to "close"-method.
If the modal is shown "forever", a slightly delay of 250 ms was added to the close()-method to avoid flickering effekt if the close()-call comes very fast. This special delay can be changed as a parameter to the close method and also as a prop to the toast-component 

I've provided also a README-section for "forever"-mode with example code for further information.

This PR is backward compatible and will not break anything.