### PR TITLE
Use the prop-types library instead of React.PropTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
  * @flow
  */
 
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import {
     StyleSheet,
     View,
@@ -14,6 +14,7 @@ import {
     Dimensions,
     Text,
 } from 'react-native'
+import PropTypes from 'prop-types';
 
 export const DURATION = { 
     LENGTH_LONG: 2000, 
@@ -130,16 +131,16 @@ const styles = StyleSheet.create({
 
 Toast.propTypes = {
     style: View.propTypes.style,
-    position: React.PropTypes.oneOf([
+    position: PropTypes.oneOf([
         'top',
         'center',
         'bottom',
     ]),
     textStyle: Text.propTypes.style,
-    positionValue: React.PropTypes.number,
-    fadeInDuration: React.PropTypes.number,
-    fadeOutDuration: React.PropTypes.number,
-    opacity: React.PropTypes.number
+    positionValue: PropTypes.number,
+    fadeInDuration: PropTypes.number,
+    fadeOutDuration: PropTypes.number,
+    opacity: PropTypes.number
 }
 
 Toast.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "peerDependencies": {
     "react-native": ">=0.20.0"
   },
-  "homepage": "https://github.com/crazycodeboy/react-native-easy-toast#readme"
+  "homepage": "https://github.com/crazycodeboy/react-native-easy-toast#readme",
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  }
 }


### PR DESCRIPTION
React.PropTypes has moved into the prop-types package since React v15.5.