### PR TITLE
React 16 problem : Remove React.PropTypes use prop-types instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ import {
     Dimensions,
     Text,
 } from 'react-native'
+import PropTypes from 'prop-types'
 
 export const DURATION = { 
     LENGTH_LONG: 2000, 
@@ -130,16 +131,16 @@ const styles = StyleSheet.create({
 
 Toast.propTypes = {
     style: View.propTypes.style,
-    position: React.PropTypes.oneOf([
+    position: PropTypes.oneOf([
         'top',
         'center',
         'bottom',
     ]),
     textStyle: Text.propTypes.style,
-    positionValue: React.PropTypes.number,
-    fadeInDuration: React.PropTypes.number,
-    fadeOutDuration: React.PropTypes.number,
-    opacity: React.PropTypes.number
+    positionValue: PropTypes.number,
+    fadeInDuration: PropTypes.number,
+    fadeOutDuration: PropTypes.number,
+    opacity: PropTypes.number
 }
 
 Toast.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "bugs": {
     "url": "https://github.com/crazycodeboy/react-native-easy-toast/issues"
   },
+   "dependencies": {
+        "prop-types": "^15.5.10"
+  },
   "peerDependencies": {
     "react-native": ">=0.20.0"
   },


### PR DESCRIPTION
React.PropTypes is removed in newer versions of React so we need to install prop-types dependency and use it instead, otherwise we get error:
"React.PropTypes  is undefined"