### PR TITLE
fix stray quote in README markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,14 @@ That's it, you're ready to go!
 Show a toast forever until you manually close it:
 ```javascript
  this.refs.toast.show('hello world!', DURATION.FOREVER);
+
+ // later on:
+ this.refs.toast.close('hello world!');
 ```
 
 Or pass an element:
 ```javascript
-    this.refs.toast.show(<View><Text>hello world!</Text></View>);
-```
-
- // later on:
- this.refs.toast.close('hello world!');
+ this.refs.toast.show(<View><Text>hello world!</Text></View>);
 ```
 
 Optional you can pass a delay in seconds to the close()-method:


### PR DESCRIPTION
Fix stray quote in README.md. (that I accidentally broke while adding the line below it, doh)