### PR TITLE
Fix `setState` warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,24 +37,26 @@ export default class Toast extends Component {
     }
 
     show(text, duration, callback) {
-        this.duration = typeof duration === 'number' ? duration : DURATION.LENGTH_SHORT;
-        this.callback = callback;
-        this.setState({
-            isShow: true,
-            text: text,
-        });
+        if (this._isMounted) {
+            this.duration = typeof duration === 'number' ? duration : DURATION.LENGTH_SHORT;
+            this.callback = callback;
+            this.setState({
+                isShow: true,
+                text: text,
+            });
 
-        this.animation = Animated.timing(
-            this.state.opacityValue,
-            {
-                toValue: this.props.opacity,
-                duration: this.props.fadeInDuration,
-            }
-        )
-        this.animation.start(() => {
-            this.isShow = true;
-            if(duration !== DURATION.FOREVER) this.close();
-        });
+            this.animation = Animated.timing(
+              this.state.opacityValue,
+              {
+                  toValue: this.props.opacity,
+                  duration: this.props.fadeInDuration,
+              }
+            )
+            this.animation.start(() => {
+                this.isShow = true;
+                if (duration !== DURATION.FOREVER) this.close();
+            });
+        }
     }
 
     close( duration ) {
@@ -84,9 +86,14 @@ export default class Toast extends Component {
         }, delay);
     }
 
+    componentDidMount() {
+        this._isMounted = true;
+    }
+
     componentWillUnmount() {
         this.animation && this.animation.stop()
         this.timer && clearTimeout(this.timer);
+        this._isMounted = false;
     }
 
     render() {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ import {
 
 import PropTypes from 'prop-types';
 const ViewPropTypes = RNViewPropTypes || View.propTypes;
-export const DURATION = { 
+export const DURATION = {
     LENGTH_SHORT: 500,
     FOREVER: 0,
 };
@@ -75,9 +75,11 @@ export default class Toast extends Component {
                 }
             )
             this.animation.start(() => {
-                this.setState({
-                    isShow: false,
-                });
+                if (this._isMounted) {
+                    this.setState({
+                        isShow: false,
+                    });
+                }
                 this.isShow = false;
                 if(typeof this.callback === 'function') {
                     this.callback();


### PR DESCRIPTION
This PR fixes a warning that can be trigged if and when the component tries to call `setState` when no longer mounted. The fix involves maintaining a flag that is updated when the component mounts/unmounts and only calling `setState` if the flag indicates that the component is currently mounted.