### PR TITLE
Add useNativeDriver property required for Animated

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ export default class Toast extends Component {
             {
                 toValue: this.props.opacity,
                 duration: this.props.fadeInDuration,
+                useNativeDriver: true,
             }
         )
         this.animation.start(() => {
@@ -70,6 +71,7 @@ export default class Toast extends Component {
                 {
                     toValue: 0.0,
                     duration: this.props.fadeOutDuration,
+                    useNativeDriver: true,
                 }
             )
             this.animation.start(() => {


### PR DESCRIPTION
Animated from react native has a required property called `useNativeDriver`.

https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated

Take a look at smartphone screenshot below:

<img src="https://i.imgur.com/PuJLWD0.jpg" width="200" />

Using Expo version: SDK 39

